### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ### What's Yogurl?
 
-Yogurl is the simple command line tool for [Yogurl.io](https://yogurl.io)
+Yogurl is the simple command line tool for [Yogurl.io](http://yogurl.io)
 
 It can be used as a [CLI](#cli-installation) command or as a [Node dependency](#node-usage) if you prefer.
 


### PR DESCRIPTION
https://yogurl.io seems to be redirecting me to the same page as https://getfuffa.com/ .
It appears that only the way to get to the right page is by using http.

I would be glad to fix it but at this point its server side and would would require server access.

Potential solutions to the problem:
-Look for any domain forwarding conflicts
-Try looking at your redirects
-Check SSL settings